### PR TITLE
migration to new groupId

### DIFF
--- a/archetypes/dukes-age-archetype/pom.xml
+++ b/archetypes/dukes-age-archetype/pom.xml
@@ -12,36 +12,33 @@
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.glassfish.docs</groupId>
-  <artifactId>dukes-age-archetype</artifactId>
-  <packaging>maven-archetype</packaging>
+    <parent>
+        <groupId>jakarta.firstcup</groupId>
+        <artifactId>archetypes</artifactId>
+        <version>8.1-SNAPSHOT</version>
+    </parent>
 
-  <name>dukes-age-archetype</name>
-  
-  <parent>
-      <groupId>org.glassfish.docs</groupId>
-      <artifactId>archetypes</artifactId>
-      <version>8.1-SNAPSHOT</version>
-  </parent>
+    <artifactId>dukes-age-archetype</artifactId>
+    <packaging>maven-archetype</packaging>
 
-  <build>
-    <extensions>
-      <extension>
-        <groupId>org.apache.maven.archetype</groupId>
-        <artifactId>archetype-packaging</artifactId>
-        <version>2.2</version>
-      </extension>
-    </extensions>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.archetype</groupId>
+                <artifactId>archetype-packaging</artifactId>
+                <version>2.2</version>
+            </extension>
+        </extensions>
 
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-archetype-plugin</artifactId>
-          <version>2.2</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-archetype-plugin</artifactId>
+                    <version>2.2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/archetypes/firstcup-war-archetype/pom.xml
+++ b/archetypes/firstcup-war-archetype/pom.xml
@@ -14,17 +14,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.glassfish.docs</groupId>
-    <artifactId>firstcup-war-archetype</artifactId>
-    <packaging>maven-archetype</packaging>
-
-    <name>firstcup-war-archetype</name>
-
     <parent>
-        <groupId>org.glassfish.docs</groupId>
+        <groupId>jakarta.firstcup</groupId>
         <artifactId>archetypes</artifactId>
         <version>8.1-SNAPSHOT</version>
     </parent>
+
+    <artifactId>firstcup-war-archetype</artifactId>
+    <packaging>maven-archetype</packaging>
+
+    <description>The web front-end for the First Cup Tutorial example.</description>
 
     <build>
         <extensions>
@@ -44,6 +43,4 @@
             </plugins>
         </pluginManagement>
     </build>
-
-    <description>The web front-end for the First Cup Tutorial example.</description>
 </project>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -12,20 +12,18 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.glassfish.docs</groupId>
-    <artifactId>archetypes</artifactId>
-    <packaging>pom</packaging>
-    <name>archetypes</name>
-  
+
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>firstcup-examples</artifactId>
+        <groupId>jakarta.firstcup</groupId>
+        <artifactId>examples</artifactId>
         <version>8.1-SNAPSHOT</version>
     </parent>
-    
+
+    <artifactId>archetypes</artifactId>
+    <packaging>pom</packaging>
+
     <modules>
         <module>dukes-age-archetype</module>
         <module>firstcup-war-archetype</module>
     </modules>
-    
 </project>

--- a/dukes-age/pom.xml
+++ b/dukes-age/pom.xml
@@ -12,15 +12,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
-        <artifactId>firstcup-examples</artifactId>
-        <groupId>org.glassfish.docs</groupId>
+        <groupId>jakarta.firstcup</groupId>
+        <artifactId>examples</artifactId>
         <version>8.1-SNAPSHOT</version>
     </parent>
         
     <artifactId>dukes-age</artifactId>
     <packaging>war</packaging>
-    <name>dukes-age</name>
-    
 </project>

--- a/firstcup-war/pom.xml
+++ b/firstcup-war/pom.xml
@@ -13,15 +13,14 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
-        <artifactId>firstcup-examples</artifactId>
-        <groupId>org.glassfish.docs</groupId>
+        <groupId>jakarta.firstcup</groupId>
+        <artifactId>examples</artifactId>
         <version>8.1-SNAPSHOT</version>
     </parent>    
+
     <artifactId>firstcup-war</artifactId>
     <packaging>war</packaging>
-    <name>${project.artifactId}</name>
     <description>The web front-end for the First Cup Tutorial example.</description>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
         <connection>scm:git:git@github.com:eclipse-ee4j/jakartaee-firstcup-examples.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse-ee4j/jakartaee-firstcup-examples.git</developerConnection>
         <url>https://github.com/eclipse-ee4j/jakartaee-firstcup-examples</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
     <issueManagement>
         <system>IssueTracker</system>
         <url>https://github.com/eclipse-ee4j/jakartaee-firstcup-examples/issues</url>
@@ -114,5 +114,4 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
 </project>


### PR DESCRIPTION
Renamed `groupId` from `org.glassfish.docs` to `jakarta.firstcup` in subprojects.