### PR TITLE
Adjusting for the tags xml be at the top of the page.

### DIFF
--- a/archetypes/dukes-age-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/archetypes/dukes-age-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -1,3 +1,7 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
@@ -9,11 +13,6 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
-
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-<?xml version="1.0" encoding="UTF-8"?>
 <web-app version="3.1" 
          xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/persistence.xml
+++ b/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/persistence.xml
@@ -1,3 +1,7 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
@@ -9,11 +13,6 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
-
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-<?xml version="1.0" encoding="UTF-8"?>
 <persistence version="2.1" 
              xmlns="http://xmlns.jcp.org/xml/ns/persistence" 
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/faces-config.xml
+++ b/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,3 +1,7 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<?xml version='1.0' encoding='UTF-8'?>
 <!--
 
     Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
@@ -9,11 +13,6 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
-
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-<?xml version='1.0' encoding='UTF-8'?>
 
 <!-- =========== FULL CONFIGURATION FILE ================================== -->
 

--- a/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -1,3 +1,7 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
@@ -9,11 +13,6 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
-
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-<?xml version="1.0" encoding="UTF-8"?>
 <web-app version="3.1"
     xmlns="http://xmlns.jcp.org/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 


### PR DESCRIPTION
fixing a bug, when the archetype is built and installed the tag `<?xml version="1.0" encoding="UTF-8"?>` is not the first thing at the top of the page, breaking the code when the archetype is used.