### PR TITLE
bugfixes archetypes xml like files and faces config file for translation

### DIFF
--- a/archetypes/dukes-age-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/archetypes/dukes-age-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -1,3 +1,8 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
 
     Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
@@ -10,10 +15,6 @@
 
 -->
 
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-<?xml version="1.0" encoding="UTF-8"?>
 <web-app
     xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/persistence.xml
+++ b/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,10 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,10 +14,6 @@
 
 -->
 
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-<?xml version="1.0" encoding="UTF-8"?>
 <persistence version="2.1" 
              xmlns="http://xmlns.jcp.org/xml/ns/persistence" 
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/faces-config.xml
+++ b/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,6 +1,10 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<?xml version='1.0' encoding='UTF-8'?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -9,11 +13,6 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
-
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-<?xml version='1.0' encoding='UTF-8'?>
 
 <!-- =========== FULL CONFIGURATION FILE ================================== -->
 
@@ -25,7 +24,7 @@
 
     <application>
         <resource-bundle>
-            <base-name>${package}.web.WebMessages</base-name>
+            <base-name>firstcup.web.WebMessages</base-name>
             <var>bundle</var>
         </resource-bundle>
         <locale-config>

--- a/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -1,3 +1,7 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
@@ -10,10 +14,6 @@
 
 -->
 
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-<?xml version="1.0" encoding="UTF-8"?>
 <web-app
     xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/webapp/greeting.xhtml
+++ b/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/webapp/greeting.xhtml
@@ -1,6 +1,10 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,19 +14,6 @@
 
 -->
 
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
-
-    You may not modify, use, reproduce, or distribute this software except in
-    compliance with  the terms of the License at:
-    https://github.com/javaee/firstcup-examples/LICENSE.txt
-
--->
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="jakarta.faces.html"

--- a/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/webapp/resources/components/inputDate.xhtml
+++ b/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/webapp/resources/components/inputDate.xhtml
@@ -1,6 +1,10 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<?xml version='1.0' encoding='UTF-8' ?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,19 +14,6 @@
 
 -->
 
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-<?xml version='1.0' encoding='UTF-8' ?>
-<!--
-
-    Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
-
-    You may not modify, use, reproduce, or distribute this software except in
-    compliance with  the terms of the License at:
-    https://github.com/javaee/firstcup-examples/LICENSE.txt
-
--->
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:cc="jakarta.faces.composite"

--- a/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/webapp/response.xhtml
+++ b/archetypes/firstcup-war-archetype/src/main/resources/archetype-resources/src/main/webapp/response.xhtml
@@ -1,6 +1,10 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<?xml version='1.0' encoding='UTF-8' ?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,19 +14,6 @@
 
 -->
 
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-<?xml version='1.0' encoding='UTF-8' ?>
-<!--
-
-    Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
-
-    You may not modify, use, reproduce, or distribute this software except in
-    compliance with  the terms of the License at:
-    https://github.com/javaee/firstcup-examples/LICENSE.txt
-
--->
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="jakarta.faces.html">


### PR DESCRIPTION
I saw when i try using archetype that i could not build it because header for copyright in xml like files (xml and xhtml) were in the top, but it provoke error when we compile so i modify these to put xml tag in the top and change face config file to put the correct classpath to translation files